### PR TITLE
bugfix/change discord api url

### DIFF
--- a/template/services/discord_api_wrapper.py
+++ b/template/services/discord_api_wrapper.py
@@ -3,7 +3,7 @@ import aiohttp
 import bittensor as bt
 from typing import Optional
 
-BASE_URL = "http://daturadiscordapi.us-east-1.elasticbeanstalk.com"
+BASE_URL = "http://api-discord.datura.ai"
 
 class DiscordAPIClient:
     def __init__(


### PR DESCRIPTION
Updated base url of discord api wrapper from ESB domain to [api-discord.datura.ai](http://api-discord.datura.ai)